### PR TITLE
Replaces deprecated set-output commands with GITHUB_OUTPUT

### DIFF
--- a/build-jar/action.yml
+++ b/build-jar/action.yml
@@ -74,12 +74,12 @@ runs:
 
     - name: Get artifact ID
       id: artifact-id
-      run: echo "::set-output name=value::$(atlas-mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout | grep -v '\[' | tail -1)"
+      run: echo "value=$(atlas-mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout | grep -v '\[' | tail -1)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get current version
       id: current-version
-      run: echo "::set-output name=value::$(atlas-mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[' | tail -1)"
+      run: echo "value=$(atlas-mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[' | tail -1)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print current version
@@ -88,7 +88,7 @@ runs:
 
     - name: Check if version changed
       id: version-changed
-      run: echo "::set-output name=value::${{ inputs.release-version != steps.current-version.outputs.value }}"
+      run: echo "value=${{ inputs.release-version != steps.current-version.outputs.value }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print version changed
@@ -117,8 +117,8 @@ runs:
     - name: Get jar file name
       id: get-jar-file
       run: |
-        echo "::set-output name=name::${{ steps.artifact-id.outputs.value }}-${{ inputs.release-version }}.jar"
-        echo "::set-output name=archive::${{ steps.artifact-id.outputs.value }}-${{ inputs.release-version }}"
+        echo "name=${{ steps.artifact-id.outputs.value }}-${{ inputs.release-version }}.jar" >> $GITHUB_OUTPUT
+        echo "archive=${{ steps.artifact-id.outputs.value }}-${{ inputs.release-version }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get addon key
@@ -153,7 +153,7 @@ runs:
 
     - name: Get head tag
       id: get-head-tag
-      run: echo "::set-output name=value::$(git tag --points-at HEAD | tail -1)"
+      run: echo "value=$(git tag --points-at HEAD | tail -1)" >> $GITHUB_OUTPUT
       if: steps.version-changed.outputs.value == 'true'
       shell: bash
 
@@ -163,7 +163,7 @@ runs:
 
     - name: Check if the new tag is at head
       id: tag-at-head
-      run: echo "::set-output name=value::${{ inputs.release-version == steps.get-head-tag.outputs.value }}"
+      run: echo "value=${{ inputs.release-version == steps.get-head-tag.outputs.value }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print is new tag at head
@@ -172,7 +172,7 @@ runs:
 
     - name: Check if should bump version
       id: should-bump-version
-      run: echo "::set-output name=value::${{ steps.version-changed.outputs.value == 'true' && steps.tag-at-head.outputs.value == 'true' }}"
+      run: echo "value=${{ steps.version-changed.outputs.value == 'true' && steps.tag-at-head.outputs.value == 'true' }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print should bump version

--- a/marketplace/action.yml
+++ b/marketplace/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
     - name: Set marketplace base URL
       id: mp-base-url
-      run: echo "::set-output name=value::https://marketplace.atlassian.com"
+      run: echo "value=https://marketplace.atlassian.com" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get marketplace info
@@ -38,8 +38,8 @@ runs:
     - name: Extract marketplace endpoints
       id: mp-endpoint
       run: |
-        echo "::set-output name=assets::${{ fromJSON(steps.mp-info.outputs.response)._links.assets.href }}"
-        echo "::set-output name=addons::${{ fromJSON(steps.mp-info.outputs.response)._links.addons.href }}"
+        echo "assets=${{ fromJSON(steps.mp-info.outputs.response)._links.assets.href }}" >> $GITHUB_OUTPUT
+        echo "addons=${{ fromJSON(steps.mp-info.outputs.response)._links.addons.href }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get marketplace asset info
@@ -51,7 +51,7 @@ runs:
 
     - name: Extract marketplace artifact endpoint
       id: mp-artifact-endpoint
-      run: echo "::set-output name=value::${{ fromJSON(steps.mp-asset-info.outputs.response)._links.artifact.href }}"
+      run: echo "value=${{ fromJSON(steps.mp-asset-info.outputs.response)._links.artifact.href }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Upload to marketplace
@@ -67,7 +67,7 @@ runs:
 
     - name: Extract marketplace upload endpoint
       id: mp-upload-endpoint
-      run: echo "::set-output name=value::${{ fromJSON(steps.mp-upload.outputs.response)._links.self.href }}"
+      run: echo "value=${{ fromJSON(steps.mp-upload.outputs.response)._links.self.href }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get marketplace addons APIs
@@ -79,7 +79,7 @@ runs:
 
     - name: Extract marketplace addon endpoint template
       id: mp-addon-endpoint-template
-      run: echo "::set-output name=value::${{ fromJSON(steps.mp-addon-api.outputs.response)._links.byKey.href }}"
+      run: echo "value=${{ fromJSON(steps.mp-addon-api.outputs.response)._links.byKey.href }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Build marketplace addon endpoint
@@ -101,7 +101,7 @@ runs:
 
     - name: Extract marketplace addons version endpoint
       id: mp-addon-version-endpoint
-      run: echo "::set-output name=value::${{ fromJSON(steps.mp-addon-info.outputs.response)._links.versions.href }}"
+      run: echo "value=${{ fromJSON(steps.mp-addon-info.outputs.response)._links.versions.href }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Create new marketplace version

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Check if package.json is exist
       id: is-node-project
-      run: echo ::set-output name=value::$(test -e package.json && echo true || echo false)
+      run: echo "value=$(test -e package.json && echo true || echo false)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print is node project
@@ -25,8 +25,8 @@ runs:
     - name: Extract npm and node version
       id: engines
       run: |
-        echo ::set-output name=node::$(cat package.json | jq -r '.engines.node')
-        echo ::set-output name=npm::$(cat package.json | jq -r '.engines.npm')
+        echo "node=$(cat package.json | jq -r '.engines.node')" >> $GITHUB_OUTPUT
+        echo "npm=$(cat package.json | jq -r '.engines.npm')" >> $GITHUB_OUTPUT
       if: steps.is-node-project.outputs.value == 'true'
       shell: bash
 

--- a/verify-release-tag/action.yml
+++ b/verify-release-tag/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Get release version
       id: release-version
-      run: echo ::set-output name=value::${{ github.event.release.tag_name }}
+      run: echo "value=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print tag version
@@ -31,7 +31,7 @@ runs:
 
     - name: Check if branch ${{ inputs.branch }} contain tag ${{ inputs.tag }}
       id: branch-contains-tag
-      run: echo "::set-output name=value::$(git branch --contains ${{ inputs.tag }} | grep -E '(^|\s)${{ inputs.branch }}')"
+      run: echo "value=$(git branch --contains ${{ inputs.tag }} | grep -E '(^|\s)${{ inputs.branch }}')" >> $GITHUB_OUTPUT
       shell: bash
       
     - name: Print branch-contains-tag


### PR DESCRIPTION
This is a 5-min minor change that I've done using claude code. It will prevent warning annotations int the PR [like we can see here](https://github.com/Atlas-Authority/nafj/actions/runs/18150564890)

Updates all GitHub Actions workflow files to use the new $GITHUB_OUTPUT syntax instead of the deprecated ::set-output command, as per GitHub's deprecation notice:

https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/